### PR TITLE
Bump sanitize gem 2.0.6 -> 4.6.4 and adjust specs to match.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,24 @@ PATH
   remote: .
   specs:
     sanitized_attributes (1.3.0)
-      sanitize (~> 2.0.0)
+      sanitize (~> 4.6.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
+    crass (1.0.3)
     diff-lcs (1.2.5)
-    mini_portile2 (2.1.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    method_source (0.8.2)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    nokogumbo (1.5.0)
+      nokogiri
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -24,15 +33,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    sanitize (2.0.6)
+    sanitize (4.6.4)
+      crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   rspec (~> 3.3.0)
   sanitized_attributes!
 
 BUNDLED WITH
-   1.12.5
+   1.15.4

--- a/sanitized_attributes.gemspec
+++ b/sanitized_attributes.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 3
   s.add_development_dependency(%q<rspec>, ["~> 3.3.0"])
-  s.add_runtime_dependency(%q<sanitize>, ["~> 2.0.0"])
+  s.add_development_dependency(%q<pry>)
+  s.add_runtime_dependency(%q<sanitize>, ["~> 4.6.4"])
 end
 

--- a/spec/sanitized_attributes_spec.rb
+++ b/spec/sanitized_attributes_spec.rb
@@ -47,10 +47,10 @@ describe "SanitizedAttributes" do
     end
     obj = @klass.new
     obj.orz = "<a>Orz are not *many bubbles* like <p/>*campers*. <p></p>Orz <b>are just</b> Orz. <p>- Orz</p>"
-    obj.orz.should == "<a rel=\"nofollow\">Orz are not *many bubbles* like <p></p>*campers*. <p></p>Orz <b>are just</b> Orz. <p>- Orz</p></a>"
+    obj.orz.should == "<a rel=\"nofollow\">Orz are not *many bubbles* like <p>*campers*. </p><p></p>Orz <b>are just</b> Orz. <p>- Orz</p></a>"
     SanitizedAttributes.add_profile(:default, Sanitize::Config::BASIC.merge(:no_empties => %w[p]))
     obj.orz = "<a>Orz are not *many bubbles* like <p/>*campers*. <p></p>Orz <b>are just</b> Orz. <p>- Orz</p>"
-    obj.orz.should == "<a rel=\"nofollow\">Orz are not *many bubbles* like *campers*. Orz <b>are just</b> Orz. <p>- Orz</p></a>"
+    obj.orz.should == "<a rel=\"nofollow\">Orz are not *many bubbles* like <p>*campers*. </p>Orz <b>are just</b> Orz. <p>- Orz</p></a>"
   end
 
   it "sanitizes attributes with custom options and profiles" do
@@ -62,6 +62,6 @@ describe "SanitizedAttributes" do
     obj.vux = "<blockquote>Our special today is <b>particle fragmentation!</b></blockquote> - VUX"
     obj.vux.should == "<blockquote>Our special today is particle fragmentation!</blockquote> - VUX"
     obj.orz = "\r\nOrz are not *many bubbles* like <p/>*campers*. <p></p>Orz <b>\r\nare just</b> Orz. <p>- Orz</p>"
-    obj.orz.should == "\nOrz are not *many bubbles* like *campers*. Orz\nare just Orz. <p>- Orz</p>"
+    obj.orz.should == "\nOrz are not *many bubbles* like <p>*campers*. </p>Orz\nare just Orz. <p>- Orz</p>"
   end
 end


### PR DESCRIPTION
This is in response to an automated security report from github for CVE-2018-3740. More details here: http://seclists.org/oss-sec/2018/q1/254

It looks like the sanitize gem introduced a different method of fixing closing tags that don't follow an opening tag. It used to treat that tag as empty, in which case our `no_empties` option would remove it. Now it appears to treat the closing tag as an opening tag and then insert a corresponding closing tag just before the next opening tag. I don't think our expectations were tied to that specific prior behavior because we use it mainly for enforcing whitelist tags. Which content is contained in the whitelisted tags is less of a concern.
